### PR TITLE
feat(heic): added capture photo in heic format (ios)

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -11,13 +11,15 @@
 
 @interface RNCamera : UIView <AVCaptureMetadataOutputObjectsDelegate,
                               AVCaptureFileOutputRecordingDelegate,
-                              AVCaptureVideoDataOutputSampleBufferDelegate>
+                              AVCaptureVideoDataOutputSampleBufferDelegate,
+                              AVCapturePhotoCaptureDelegate>
 
 @property(nonatomic, strong) dispatch_queue_t sessionQueue;
 @property(nonatomic, strong) AVCaptureSession *session;
 @property(nonatomic, strong) AVCaptureDeviceInput *videoCaptureDeviceInput;
 @property(nonatomic, strong) AVCaptureDeviceInput *audioCaptureDeviceInput;
 @property(nonatomic, strong) AVCaptureStillImageOutput *stillImageOutput;
+@property(nonatomic, strong) AVCapturePhotoOutput *photoOutput;
 @property(nonatomic, strong) AVCaptureMovieFileOutput *movieFileOutput;
 @property(nonatomic, strong) AVCaptureMetadataOutput *metadataOutput;
 @property(nonatomic, strong) AVCaptureVideoDataOutput *videoDataOutput;

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -76,7 +76,7 @@ RCT_EXPORT_VIEW_PROPERTY(onTouch, RCTDirectEventBlock);
                      @"portrait": @(RNCameraOrientationPortrait),
                      @"portraitUpsideDown": @(RNCameraOrientationPortraitUpsideDown)
                      },
-             @"AVVideoCodecTypeHEVC": [[self class] validCodecTypes],
+             @"VideoCodec": [[self class] validCodecTypes],
              @"BarCodeType" : [[self class] validBarCodeTypes],
              @"FaceDetection" : [[self class] faceDetectorConstants],
              @"VideoStabilization": [[self class] validVideoStabilizationModes],

--- a/ios/RN/RNCameraManager.m
+++ b/ios/RN/RNCameraManager.m
@@ -8,6 +8,7 @@
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
+#import "UIImage+HEIC.h"
 
 @implementation RNCameraManager
 
@@ -75,7 +76,7 @@ RCT_EXPORT_VIEW_PROPERTY(onTouch, RCTDirectEventBlock);
                      @"portrait": @(RNCameraOrientationPortrait),
                      @"portraitUpsideDown": @(RNCameraOrientationPortraitUpsideDown)
                      },
-             @"VideoCodec": [[self class] validCodecTypes],
+             @"AVVideoCodecTypeHEVC": [[self class] validCodecTypes],
              @"BarCodeType" : [[self class] validBarCodeTypes],
              @"FaceDetection" : [[self class] faceDetectorConstants],
              @"VideoStabilization": [[self class] validVideoStabilizationModes],
@@ -360,6 +361,9 @@ RCT_REMAP_METHOD(takePicture,
             if (options[@"path"]) {
                 path = options[@"path"];
             }
+            else if (@available(iOS 11, *)){
+                path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".heic"];
+            }
             else{
                 path = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"Camera"] withExtension:@".jpg"];
             }
@@ -370,16 +374,27 @@ RCT_REMAP_METHOD(takePicture,
             }
 
             [view onPictureTaken:@{}];
+            
+            if (@available(iOS 11, *)) {
 
-            NSData *photoData = UIImageJPEGRepresentation(generatedPhoto, quality);
-            if (![options[@"doNotSave"] boolValue]) {
-                response[@"uri"] = [RNImageUtils writeImage:photoData toPath:path];
+                NSData *photoData = tj_UIImageHEICRepresentation(generatedPhoto, quality);
+
+                if (![options[@"doNotSave"] boolValue]) {
+                    response[@"uri"] = [RNImageUtils writeImage:photoData toPath:path];
+                }
+            }else{
+                NSData *photoData = UIImageJPEGRepresentation(generatedPhoto, quality);
+                if (![options[@"doNotSave"] boolValue]) {
+                    response[@"uri"] = [RNImageUtils writeImage:photoData toPath:path];
+                }
+                if ([options[@"base64"] boolValue]) {
+                    response[@"base64"] = [photoData base64EncodedStringWithOptions:0];
+                }
             }
+
             response[@"width"] = @(generatedPhoto.size.width);
             response[@"height"] = @(generatedPhoto.size.height);
-            if ([options[@"base64"] boolValue]) {
-                response[@"base64"] = [photoData base64EncodedStringWithOptions:0];
-            }
+
             if (useFastMode) {
                 [view onPictureSaved:@{@"data": response, @"id": options[@"id"]}];
             } else {

--- a/ios/RN/UIImage+HEIC.h
+++ b/ios/RN/UIImage+HEIC.h
@@ -1,0 +1,41 @@
+//
+//  UIImage+HEIC.h
+//  Test
+//
+//  Created by Tim Johnsen on 10/13/17.
+//  Copyright © 2017 Tim Johnsen. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Returns and NSData HEIC representation of the image if possible, otherwise returns nil.
+NSData *_Nullable tj_UIImageHEICRepresentation(UIImage *const image, const CGFloat compressionQuality);
+
+@interface UIGraphicsImageRenderer (TJHEICAdditions)
+
+- (nullable NSData *)tj_HEICDataWithCompressionQuality:(const CGFloat)compressionQuality
+                                               actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions;
+
+- (nullable NSData *)tj_HEICDataWithCompressionQuality:(const CGFloat)compressionQuality
+           fallingBackToJPEGDataWithCompressionQuality:(const CGFloat)jpegCompressionQuality
+                                               actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions;
+
+- (nullable NSData *)tj_HEICDataFallingBackToPNGDataWithCompressionQuality:(const CGFloat)compressionQuality
+                                                                   actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions;
+
+@end
+
+@interface UIDevice (TJHEICAdditions)
+
++ (BOOL)isHEICWritingSupported;
+
+@end
+
+BOOL tj_CGImageSourceUTIIsHEIC(const CGImageSourceRef imageSource);
+BOOL tj_isImageAtPathHEIC(NSString *const path);
+
+pthread_mutex_t *tj_HEICEncodingLock(void);
+
+NS_ASSUME_NONNULL_END

--- a/ios/RN/UIImage+HEIC.m
+++ b/ios/RN/UIImage+HEIC.m
@@ -1,0 +1,144 @@
+//
+//  UIImage+HEIC.m
+//  Test
+//
+//  Created by Tim Johnsen on 10/13/17.
+//  Copyright © 2017 Tim Johnsen. All rights reserved.
+//
+
+#import "UIImage+HEIC.h"
+#import <AVFoundation/AVMediaFormat.h>
+#import <pthread.h>
+
+#define SIMULATE_HEIC_UNAVAILABLE 0
+
+NSData *_Nullable tj_UIImageHEICRepresentation(UIImage *const image, const CGFloat compressionQuality)
+{
+    NSData *imageData = nil;
+#if !SIMULATE_HEIC_UNAVAILABLE
+    if (@available(iOS 11.0, *)) {
+        if (image) {
+            NSMutableData *destinationData = [NSMutableData new];
+            CGImageDestinationRef destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)destinationData, (__bridge CFStringRef)AVFileTypeHEIC, 1, NULL);
+            if (destination) {
+                NSDictionary *options = @{(__bridge NSString *)kCGImageDestinationLossyCompressionQuality: @(compressionQuality)};
+
+                // iOS devices seem to corrupt image data when concurrently creating HEIC images.
+                // Locking to ensure HEIC creation doesn't occur concurrently.
+                pthread_mutex_t *lock = tj_HEICEncodingLock();
+                pthread_mutex_lock(lock);
+                
+                CGImageDestinationAddImage(destination, image.CGImage, (__bridge CFDictionaryRef)options);
+                CGImageDestinationFinalize(destination);
+                
+                pthread_mutex_unlock(lock);
+                
+                imageData = destinationData;
+                CFRelease(destination);
+            }
+        }
+    }
+#endif
+    return imageData;
+}
+
+@implementation UIGraphicsImageRenderer (TJHEICAdditions)
+
+- (nullable NSData *)tj_HEICDataWithCompressionQuality:(const CGFloat)compressionQuality
+                                               actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions
+{
+    return [self tj_HEICDataWithCompressionQuality:compressionQuality
+                                           actions:actions
+                                          fallback:nil];
+}
+
+- (nullable NSData *)tj_HEICDataWithCompressionQuality:(const CGFloat)compressionQuality
+           fallingBackToJPEGDataWithCompressionQuality:(const CGFloat)jpegCompressionQuality
+                                               actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions
+{
+    return [self tj_HEICDataWithCompressionQuality:compressionQuality
+                                           actions:actions
+                                          fallback:^NSData *(UIImage *image) {
+                                              return UIImageJPEGRepresentation(image, jpegCompressionQuality);
+                                          }];
+}
+
+- (nullable NSData *)tj_HEICDataFallingBackToPNGDataWithCompressionQuality:(const CGFloat)compressionQuality
+                                                                   actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions
+{
+    return [self tj_HEICDataWithCompressionQuality:compressionQuality
+                                           actions:actions
+                                          fallback:^NSData *(UIImage *image) {
+                                              return UIImagePNGRepresentation(image);
+                                          }];
+}
+
+- (nullable NSData *)tj_HEICDataWithCompressionQuality:(const CGFloat)compressionQuality
+                                               actions:(NS_NOESCAPE UIGraphicsImageDrawingActions)actions
+                                              fallback:(NSData *(^)(UIImage *))fallback
+{
+    UIImage *const image = [self imageWithActions:actions];
+    NSData *data = tj_UIImageHEICRepresentation(image, compressionQuality);
+    if (data.length == 0 && fallback) {
+        data = fallback(image);
+    }
+    return data;
+}
+
+@end
+
+@implementation UIDevice (TJHEICAdditions)
+
++ (BOOL)isHEICWritingSupported
+{
+    static BOOL isHEICSupported = NO;
+#if !SIMULATE_HEIC_UNAVAILABLE
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (@available(iOS 11.0, *)) {
+            NSMutableData *data = [NSMutableData data];
+            CGImageDestinationRef destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)data, (__bridge CFStringRef)AVFileTypeHEIC, 1, nil);
+            if (destination) {
+                isHEICSupported = YES;
+                CFRelease(destination);
+            }
+        }
+    });
+#endif
+    return isHEICSupported;
+}
+
+@end
+
+BOOL tj_CGImageSourceUTIIsHEIC(const CGImageSourceRef imageSource)
+{
+    BOOL isHEIC = NO;
+    if (@available(iOS 11.0, *)) {
+        if (imageSource) {
+            NSString *const uti = (__bridge_transfer NSString *)CGImageSourceGetType(imageSource);
+            isHEIC = [uti isEqualToString:AVFileTypeHEIC];
+        }
+    }
+    return isHEIC;
+}
+
+BOOL tj_isImageAtPathHEIC(NSString *const path)
+{
+    BOOL isHEIC = NO;
+    const CGImageSourceRef imageSource = CGImageSourceCreateWithURL((__bridge CFURLRef)[NSURL fileURLWithPath:path isDirectory:NO], nil);
+    if (imageSource) {
+        isHEIC = tj_CGImageSourceUTIIsHEIC(imageSource);
+        CFRelease(imageSource);
+    }
+    return isHEIC;
+}
+
+pthread_mutex_t *tj_HEICEncodingLock(void)
+{
+    static pthread_mutex_t lock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        pthread_mutex_init(&lock, nil);
+    });
+    return &lock;
+}

--- a/ios/RNCamera.xcodeproj/project.pbxproj
+++ b/ios/RNCamera.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		71C7FFD02013C7E5006EB75A /* RNCameraUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFCF2013C7E5006EB75A /* RNCameraUtils.m */; };
 		71C7FFD32013C817006EB75A /* RNImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFD22013C817006EB75A /* RNImageUtils.m */; };
 		71C7FFD62013C824006EB75A /* RNFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C7FFD52013C824006EB75A /* RNFileSystem.m */; };
+		90B8477D248F4F44009FBCA3 /* UIImage+HEIC.m in Sources */ = {isa = PBXBuildFile; fileRef = 90B8477B248F4F44009FBCA3 /* UIImage+HEIC.m */; };
 		9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */; };
 		F8393BEC21469C0000AB1995 /* RNSensorOrientationChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = F8393BEB21469C0000AB1995 /* RNSensorOrientationChecker.m */; };
 /* End PBXBuildFile section */
@@ -57,6 +58,8 @@
 		71C7FFD22013C817006EB75A /* RNImageUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNImageUtils.m; sourceTree = "<group>"; };
 		71C7FFD42013C824006EB75A /* RNFileSystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFileSystem.h; sourceTree = "<group>"; };
 		71C7FFD52013C824006EB75A /* RNFileSystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFileSystem.m; sourceTree = "<group>"; };
+		90B8477B248F4F44009FBCA3 /* UIImage+HEIC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+HEIC.m"; sourceTree = "<group>"; };
+		90B8477C248F4F44009FBCA3 /* UIImage+HEIC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+HEIC.h"; sourceTree = "<group>"; };
 		9FE592B11CA3CBF500788287 /* RCTSensorOrientationChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTSensorOrientationChecker.h; sourceTree = "<group>"; };
 		9FE592B21CA3CBF500788287 /* RCTSensorOrientationChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTSensorOrientationChecker.m; sourceTree = "<group>"; };
 		C5627D22245D10A100B761CF /* NSMutableDictionary+ImageMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+ImageMetadata.h"; sourceTree = "<group>"; };
@@ -128,6 +131,8 @@
 				71C7FFC92013C7AE006EB75A /* RNCameraManager.m */,
 				71C7FFCB2013C7BF006EB75A /* RNCamera.h */,
 				71C7FFCC2013C7BF006EB75A /* RNCamera.m */,
+				90B8477C248F4F44009FBCA3 /* UIImage+HEIC.h */,
+				90B8477B248F4F44009FBCA3 /* UIImage+HEIC.m */,
 			);
 			path = RN;
 			sourceTree = "<group>";
@@ -198,6 +203,7 @@
 				71C7FFD02013C7E5006EB75A /* RNCameraUtils.m in Sources */,
 				7162BE682013EAA400FE51FF /* RNCameraManager.m in Sources */,
 				7162BE672013EAA100FE51FF /* RNCamera.m in Sources */,
+				90B8477D248F4F44009FBCA3 /* UIImage+HEIC.m in Sources */,
 				9FE592B31CA3CBF500788287 /* RCTSensorOrientationChecker.m in Sources */,
 				2647D6712256BBD5007D2F91 /* FaceDetectorManagerMlkit.m in Sources */,
 				71C7FFD32013C817006EB75A /* RNImageUtils.m in Sources */,


### PR DESCRIPTION
ticket: RENO-3889

- Added ability to capture photo in heic format, available for ios > 10
- Replaced deprecated API https://developer.apple.com/documentation/avfoundation/avcapturestillimageoutput with https://developer.apple.com/documentation/avfoundation/avcapturephotooutput off  AVCapturePhotoCaptureDelegate protocol
- For simulator support, used tj_UIImageHEICRepresentation from this project: https://github.com/timonus/UIImageHEIC 

Next:
- thumb resize in heic format

Additional work for submitting PR to the community will be done on a separate ticket and will include:
- all takePicture request and response options for heic route
- testing against iOS < 10 on a real device and a simulator