### PR TITLE
chore(reno-8582): Recovery & Logs from AV Interruptions

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -44,6 +44,7 @@
 @property(assign, nonatomic) AVCaptureSessionPreset pictureSize;
 @property(nonatomic, assign) BOOL isReadingBarCodes;
 @property(nonatomic, assign) BOOL isRecordingInterrupted;
+@property(nonatomic, assign) NSInteger interruptionReason;
 @property(nonatomic, assign) BOOL isDetectingFaces;
 @property(nonatomic, assign) BOOL canReadText;
 @property(nonatomic, assign) BOOL canDetectFaces;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -171,10 +171,10 @@ export interface RNCameraProps {
   /** iOS only */
   onAudioInterrupted?(): void;
   onAudioConnected?(): void;
-  onTap?(origin:Point):void;
-  onDoubleTap?(origin:Point):void;
+  onTap?(origin: Point): void;
+  onDoubleTap?(origin: Point): void;
   /** Use native pinch to zoom implementation*/
-  useNativeZoom?:boolean;
+  useNativeZoom?: boolean;
   /** Value: float from 0 to 1.0 */
   zoom?: number;
   /** iOS only. float from 0 to any. Locks the max zoom value to the provided value
@@ -413,6 +413,8 @@ export interface TakePictureResponse {
   exif?: { [name: string]: any };
   pictureOrientation: number;
   deviceOrientation: number;
+  isRecordingInterruption: boolean;
+  interruptionReason: number;
 }
 
 interface RecordOptions {


### PR DESCRIPTION
- step 1 - initial implementation to recover & log interruptions while capturing images (more to come)

> - TODO: ideally this should be handled as part of sessionRuntimeError, look if related observer might be got removed
> - TODO: add the logs also as part of the error itself (user info section)

- step 2 - added interruption reason to user info on error
(note: I checked sessionRuntimeError, the observer wasn't removed)